### PR TITLE
chore: Add overview section to compare all results easier

### DIFF
--- a/_bench/readme.ts
+++ b/_bench/readme.ts
@@ -34,6 +34,7 @@ function performance(result: Result): [Record<string, unknown>[], Options] {
     avg: requests.average,
     stdev: requests.stddev,
     min: requests.min,
+    total: requests.total
   };
   const bytes = {
     name: "**Bytes/Sec**",
@@ -44,6 +45,7 @@ function performance(result: Result): [Record<string, unknown>[], Options] {
     avg: prettyBytes(throughput.average),
     stdev: prettyBytes(throughput.stddev),
     min: prettyBytes(throughput.min),
+    total: prettyBytes(throughput.total)
   };
   const opts: Options = {
     columns: ["**Stat**", "1%", "2.5%", "50%", "95.5%", "Avg", "Stdev", "Min"],
@@ -65,6 +67,45 @@ if (import.meta.main) {
   const toc: string[] = [];
 
   toc.push("## Table of Contents\n");
+
+  // Do overview section
+  toc.push("- [Overview](#overview)");
+  markdown.push(`## Overview`);
+  for (const group of config.groups) {
+    let results: {[key: string]: {
+      average: number,
+      total: number
+    }} = {};
+    for (const benchmark of group.benchmarks) {
+      const resultPath = join(benchmark.dir, "results", `${group.name}.json`);
+      const resultSource = await Deno.readTextFile(resultPath);
+      const result = JSON.parse(resultSource) as Result;
+      results[benchmark.name] = {
+        average: result.requests.average,
+        total: result.requests.total
+      }
+    }
+    let table = "| **Framework** |"
+    // set headings
+    Object.keys(results).forEach((key) => {
+      table += ` ${key} |`
+    })
+    table += "\n| --- | "
+    Object.keys(results).forEach((key) => {
+      table += `--- |`
+    })
+    // set average row
+    table += "\n| **Average** |"
+    Object.keys(results).forEach((key) => {
+      table += ` ${results[key].average} |`
+    })
+    // set average row
+    table += "\n| **Total** |"
+    Object.keys(results).forEach((key) => {
+      table += ` ${results[key].total} |`
+    })
+    markdown.push(table)
+  }
 
   for (const group of config.groups) {
     markdown.push(`## benchmark \`${group.name}\``);


### PR DESCRIPTION
Not really adding grpahs, but more a section to easier compare results from all frameworks/tools listed.

Also adds a `total` field for each singular benchmark - but i went off on my own for this so i'm happy to remove if people aren't happy

Not really sure how to add graphs to best honest so this is my attempt at adding a result set for ease of comparison.

Not really happy about the obejct.keys looping code, ut the existing logic would be near impossible to extend/utilise.

Ran the command myself and this is what displays (in PHPStorm, so note that it would display correctly in a proper 'viewer'):

![image](https://user-images.githubusercontent.com/47337480/97309929-8a384980-185a-11eb-9455-a0efc64ab282.png)
