### PR TITLE
chore: Explicitly use latest deno version in CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -65,8 +63,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -108,8 +104,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -152,8 +146,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -196,8 +188,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -331,8 +321,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -380,8 +368,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -430,8 +416,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -480,8 +464,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -531,8 +513,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -583,8 +563,6 @@ jobs:
           node-version: '13'
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Install Autocannon
         run: npm install -g autocannon
       - name: START
@@ -632,8 +610,6 @@ jobs:
         run: git pull
       - name: Setup deno 1.x
         uses: denolib/setup-deno@v2
-        with:
-          deno-version: v1.x
       - name: Generate README.md
         run: deno run -A --unstable _bench/readme.ts
       - name: Commit & Push changes

--- a/_bench/build.ts
+++ b/_bench/build.ts
@@ -26,7 +26,6 @@ function wrap(step: Step): Step[] {
     {
       name: "Setup deno 1.x",
       uses: "denolib/setup-deno@v2",
-      with: { "deno-version": "v1.x" },
     },
     { name: "Install Autocannon", run: "npm install -g autocannon" },
     { name: "START", run: 'echo "Starting Benchmarks"' },
@@ -59,7 +58,6 @@ function generateResults(previous: string[]): Job {
       {
         name: "Setup deno 1.x",
         uses: "denolib/setup-deno@v2",
-        with: { "deno-version": "v1.x" },
       },
       {
         name: "Generate README.md",


### PR DESCRIPTION
Yes it fixes the ci by removing code... ;)

Ci was failing due to std not matching latest release - plus, you explicitly use the master branch for all deno apps so i think it would make sense to do that for all