### PR TITLE
Fix: Reno server boilerplate and compiles example prior to running

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -872,7 +872,7 @@ jobs:
       - name: reno
         run: >-
           deno compile --allow-net -o bare.out bare.ts
-          mkdir -p resultsv
+          mkdir -p results
 
           ./bare.out &
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,7 +36,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -85,7 +85,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -134,7 +134,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -183,7 +183,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -234,7 +234,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -283,7 +283,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -332,7 +332,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -381,7 +381,7 @@ jobs:
         run: >-
           npm i && node bare.js &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -430,7 +430,7 @@ jobs:
         run: >-
           npm i && node bare.js &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -479,7 +479,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -528,7 +528,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -577,7 +577,7 @@ jobs:
         run: >-
           deno run -A bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -626,7 +626,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -677,7 +677,7 @@ jobs:
         run: >-
           node bare.js &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -726,7 +726,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -775,7 +775,7 @@ jobs:
         run: >-
           deno run -A bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -824,7 +824,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -923,7 +923,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 
@@ -972,7 +972,7 @@ jobs:
         run: >-
           deno run -A bare.ts &
 
-          sleep 15 &&
+          sleep 15 && 
 
           mkdir -p results &&
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -871,7 +871,7 @@ jobs:
         run: echo "Starting Benchmarks"
       - name: reno
         run: >-
-          deno compile -o bare.out bare.ts
+          deno compile --allow-net -o bare.out bare.ts
           mkdir -p resultsv
 
           ./bare.out &

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,7 +36,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -85,7 +85,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -134,7 +134,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -183,7 +183,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -234,7 +234,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -283,7 +283,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -332,7 +332,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -381,7 +381,7 @@ jobs:
         run: >-
           npm i && node bare.js &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -430,7 +430,7 @@ jobs:
         run: >-
           npm i && node bare.js &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -479,7 +479,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -528,7 +528,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -577,7 +577,7 @@ jobs:
         run: >-
           deno run -A bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -626,7 +626,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -677,7 +677,7 @@ jobs:
         run: >-
           node bare.js &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -726,7 +726,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -775,7 +775,7 @@ jobs:
         run: >-
           deno run -A bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -824,7 +824,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -873,7 +873,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 30 &&
 
           mkdir -p results &&
 
@@ -922,7 +922,7 @@ jobs:
         run: >-
           deno run -A --unstable bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 
@@ -971,7 +971,7 @@ jobs:
         run: >-
           deno run -A bare.ts &
 
-          sleep 15 && 
+          sleep 15 &&
 
           mkdir -p results &&
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -871,11 +871,12 @@ jobs:
         run: echo "Starting Benchmarks"
       - name: reno
         run: >-
-          deno run -A --unstable bare.ts &
+          deno compile -o bare.out bare.ts
+          mkdir -p resultsv
 
-          sleep 30 &&
+          ./bare.out &
 
-          mkdir -p results &&
+          sleep 5 &&
 
           autocannon -c 40 -d 10 -j http://localhost:8000 >
           results/bare_reno.json &&

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ express/node_modules
 express/package-lock.json
 fastify/node_modules
 fastify/package-lock.json
+bare.out

--- a/reno/bare.ts
+++ b/reno/bare.ts
@@ -1,11 +1,11 @@
-import { listenAndServe } from "https://deno.land/std/http/server.ts";
+import { serve } from "https://deno.land/std/http/server.ts";
 
 import {
   createRouteMap,
   createRouter,
 } from "https://deno.land/x/reno/reno/mod.ts";
 
-const BINDING = ":8000";
+const PORT = 8000;
 
 const routes = createRouteMap([
   ["/", () => new Response("Hello, Bench!")],
@@ -13,4 +13,6 @@ const routes = createRouteMap([
 
 const router = createRouter(routes);
 
-await listenAndServe(BINDING, req => router(req));
+await serve((req) => router(req), {
+  port: PORT,
+});


### PR DESCRIPTION
Hey @eliassjogreen!

I have another small PR for you, which updates the Reno example to use the `serve()` HTTP server API in lieu of `listenAndServe()`. Also, it seems that for the Reno benchmark (and some of the others), Autocannon would run before Deno had finished downloading the dependencies and compiling the server; I've fixed this with an isolated `deno compile` step that will ensure the server is in a runnable state ahead of any benchmarking:

```sh
deno compile --allow-net -o bare.out bare.ts
mkdir -p results

./bare.out &

sleep 5 &&

autocannon -c 40 -d 10 -j http://localhost:8000 >
results/bare_reno.json &&

kill $!
```

I'd recommend making the same change to the other benchmarks.