### PR TITLE
fix: don't await `Deno.serve` in cheetah benchmark

### DIFF
--- a/frameworks/cheetah/hello_bench.ts
+++ b/frameworks/cheetah/hello_bench.ts
@@ -2,4 +2,4 @@ import cheetah from "https://deno.land/x/cheetah/mod.ts";
 
 const app = new cheetah().get("/", () => "Hello, Bench!");
 
-await Deno.serve(app.fetch, { port: 8000 });
+Deno.serve(app.fetch, { port: 8000 });


### PR DESCRIPTION
@eliassjogreen hey sorry, this should now definitely fix the benchmark for cheetah.

The benchmark broke because `Deno.serve` no longer returns a promise.