### PR TITLE
fix: don't await `Deno.serve`

### DIFF
--- a/frameworks/deno/hello_bench.ts
+++ b/frameworks/deno/hello_bench.ts
@@ -1,3 +1,3 @@
-await Deno.serve(() => new Response("Hello, Bench!"), {
+Deno.serve(() => new Response("Hello, Bench!"), {
   port: 8000,
 });

--- a/frameworks/fast/hello_bench.ts
+++ b/frameworks/fast/hello_bench.ts
@@ -4,4 +4,4 @@ const app = fast();
 
 app.get("/", () => new Response("Hello, Bench!"));
 
-await Deno.serve(app.handle, { port: 8000 });
+Deno.serve(app.handle, { port: 8000 });

--- a/frameworks/hono/hello_bench.ts
+++ b/frameworks/hono/hello_bench.ts
@@ -6,6 +6,6 @@ app.get("/", (c) => {
   return c.text("Hello, Bench!");
 });
 
-await Deno.serve((req) => app.fetch(req), {
+Deno.serve((req) => app.fetch(req), {
   port: 8000,
 });

--- a/frameworks/reno/hello_bench.ts
+++ b/frameworks/reno/hello_bench.ts
@@ -9,6 +9,6 @@ const routes = createRouteMap([
 
 const router = createRouter(routes);
 
-await Deno.serve((req) => router(req), {
+Deno.serve((req) => router(req), {
   port: 8000,
 });


### PR DESCRIPTION
This pr fixes the usage of `Deno.serve` in 4 benchmarks.