### PR TITLE
fix: cheetah serve

### DIFF
--- a/frameworks/cheetah/hello_bench.ts
+++ b/frameworks/cheetah/hello_bench.ts
@@ -2,4 +2,4 @@ import cheetah from "https://deno.land/x/cheetah/mod.ts";
 
 const app = new cheetah().get("/", () => "Hello, Bench!");
 
-Deno.serve(app.fetch, { port: 8000 });
+app.serve({ port: 8000 });


### PR DESCRIPTION
Serving using `Deno.serve()` no longer works. `cheetah.serve()` is now the recommended method