### PR TITLE
fix: force experimental decorators for danet

### DIFF
--- a/frameworks/danet/deno.json
+++ b/frameworks/danet/deno.json
@@ -1,0 +1,6 @@
+{
+  "lock": false,
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/frameworks/danet_v2/deno.json
+++ b/frameworks/danet_v2/deno.json
@@ -1,0 +1,6 @@
+{
+  "lock": false,
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}


### PR DESCRIPTION
[Danet](https://github.com/Savory/Danet) relies on experimental decorators requiring `experimentalDecorators` to be set to `true` since the release of Deno 1.40, as declared in the release [blog](https://deno.com/blog/v1.40#decorators).

This PR adds `deno.json` containing the required option to `danet` and `danet_v2` frameworks, fixing [error](https://github.com/denosaurs/bench/actions/runs/8273948480/job/22638553007#step:7:947) and [error](https://github.com/denosaurs/bench/actions/runs/8273948480/job/22638553007#step:7:1011) accordingly.

An example of a successful run can be found [here](https://github.com/ArturSharapov/denosaurs-bench/tree/workflow-test).